### PR TITLE
Fix memory leak

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -261,6 +261,11 @@ frame.
 
 =back
 
+=head2 $client->destroy
+
+Disconnects and cleans up all callbacks. To be called when the client object
+is not used any more and should be cleaned up.
+
 =head2 Callbacks
 
 In order for the C<AnyEvent::STOMP::Client> to be useful, callback subroutines

--- a/lib/AnyEvent/STOMP/Client.pm
+++ b/lib/AnyEvent/STOMP/Client.pm
@@ -233,9 +233,6 @@ sub set_heartbeat_intervals {
 
 sub reset_client_heartbeat_timer {
     my $self = shift;
-
-    #return unless $self->{connected};
-
     my $interval = $self->{heartbeat}{interval}{client};
 
     unless (defined $interval and $interval > 0) {

--- a/lib/AnyEvent/STOMP/Client.pm
+++ b/lib/AnyEvent/STOMP/Client.pm
@@ -138,8 +138,10 @@ sub disconnect {
     unless ($self->is_connected) {
         if (defined $self->{handle}) {
             $self->{handle}->destroy;
+            delete $self->{handle};
         }
         $self->event('DISCONNECTED', $self->{host}, $self->{port}, $ungraceful);
+        delete $self->{heartbeat}{timer};
         return;
     }
 
@@ -149,8 +151,10 @@ sub disconnect {
         if (defined $self->{handle}) {
             $self->{handle}->push_shutdown;
             $self->{handle}->destroy;
+            delete $self->{handle};
         }
         $self->event('DISCONNECTED', $self->{host}, $self->{port}, $ungraceful);
+        delete $self->{heartbeat}{timer};
     }
     else {
         my $receipt_id = $self->get_uuid;
@@ -168,12 +172,20 @@ sub disconnect {
                     if (defined $self->{handle}) {
                         $self->{handle}->push_shutdown;
                         $self->{handle}->destroy;
+                        delete $self->{handle};
                     }
                     $self->event('DISCONNECTED', $self->{host}, $self->{port}, $ungraceful);
+                    delete $self->{heartbeat}{timer};
                 }
             }
         );
     }
+}
+
+sub destroy {
+    my $self = shift;
+    $self->disconnect(1) if $self->is_connected;
+    $self->remove_all_callbacks;
 }
 
 sub DESTROY {
@@ -221,6 +233,9 @@ sub set_heartbeat_intervals {
 
 sub reset_client_heartbeat_timer {
     my $self = shift;
+
+    #return unless $self->{connected};
+
     my $interval = $self->{heartbeat}{interval}{client};
 
     unless (defined $interval and $interval > 0) {


### PR DESCRIPTION
I wanted to fully clean up a `AnyEvent::STOMP::Client` object but it was not destroyed because of circular references.
So I added some further cleanup in `disconnect` and a `destroy` method to be able to signal from externally that the object should be teared down. It disconnects the STOMP connection and unregistered all callbacks after.