### PR TITLE
there is no header in the error callback

### DIFF
--- a/lib/AnyEvent/STOMP/Client/All.pm
+++ b/lib/AnyEvent/STOMP/Client/All.pm
@@ -68,8 +68,8 @@ sub setup_stomp_clients {
 
         $self->{stomp_clients}{$id}->on_error(
             sub {
-                my (undef, $header, undef) = @_;
-                $log->warn("$id STOMP ERROR $header->{message}.");
+                my (undef, undef, undef, $error) = @_;
+                $log->warn("$id STOMP ERROR $error");
             }
         );
 

--- a/lib/AnyEvent/STOMP/Client/Any.pm
+++ b/lib/AnyEvent/STOMP/Client/Any.pm
@@ -104,7 +104,7 @@ sub setup_stomp_clients {
 
                 delete $self->{current_stomp_client};
 
-                $log->debug("$id STOMP ERROR received: 'error'.");
+                $log->debug("$id STOMP ERROR received: '$error'.");
                 $self->event('ANY_ERROR', $error, $id);
             }
         );

--- a/lib/AnyEvent/STOMP/Client/Any.pm
+++ b/lib/AnyEvent/STOMP/Client/Any.pm
@@ -100,12 +100,12 @@ sub setup_stomp_clients {
 
         $self->{stomp_clients}{$id}->on_error(
             sub {
-                my (undef, $header, undef) = @_;
+                my (undef, undef, undef, $error) = @_;
 
                 delete $self->{current_stomp_client};
 
-                $log->debug("$id STOMP ERROR received: '$header->{message}'.");
-                $self->event('ANY_ERROR', $header->{message}, $id);
+                $log->debug("$id STOMP ERROR received: 'error'.");
+                $self->event('ANY_ERROR', $error, $id);
             }
         );
 


### PR DESCRIPTION
fixes
```
recursion through exception callback (ERROR AnyEvent::STOMP::Client=HASH(0x2bcaf98) 213.156.236.13 5551 Internal Server Error: org.apache.activemq.apollo.stomp.StompProtocolHandler$ProtocolException: Invalid stomp destination name: file.copy) => (ERROR, AnyEvent::STOMP::Client=HASH(0x2bcaf98), 213.156.236.13 5551 ERROR: Can't use string ("213.156.236.13") as a HASH ref while "strict refs" in use at /opt/OSAGbalu/lib/AnyEvent/STOMP/Client/Any.pm line 107.
```