### PR TITLE
Bugfix to remove NULL character frame delimiter from frame body

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl module AnyEvent::STOMP::Client.
 
+0.42  2024-06-18
+      - Bugfix to remove NULL character frame delimiter from frame body
+
 0.41  2022-02-14
       - Avoid memory leak by allowing to fully shutdown the client object (by @kbucheli)
       - Properly fish error message from the header of the stomp ERROR message (by @kbucheli)

--- a/lib/AnyEvent/STOMP/Client.pm
+++ b/lib/AnyEvent/STOMP/Client.pm
@@ -11,7 +11,7 @@ use AnyEvent::Handle;
 use List::Util 'max';
 
 
-our $VERSION = '0.41';
+our $VERSION = '0.42';
 
 
 my $EOL = chr(10);
@@ -607,6 +607,15 @@ sub read_frame {
                                 }
                                 else {
                                     $self->event('MESSAGE', $header_hashref, $body);
+
+                                    # If frame end was determined by matching
+                                    # for a NULL character, then this character
+                                    # is not part of the frame body and thus
+                                    # removed
+                                    if (exists $args->{regex}) {
+                                        $body =~ s/\0$//g;
+                                    }
+
 
                                     if (defined $header_hashref->{subscription}) {
                                         $self->event(

--- a/lib/AnyEvent/STOMP/Client/All.pm
+++ b/lib/AnyEvent/STOMP/Client/All.pm
@@ -10,7 +10,7 @@ use Log::Any qw($log);
 use AnyEvent::STOMP::Client;
 
 
-our $VERSION = '0.41';
+our $VERSION = '0.42';
 
 
 my $SEPARATOR_ID_ACK = '#';

--- a/lib/AnyEvent/STOMP/Client/Any.pm
+++ b/lib/AnyEvent/STOMP/Client/Any.pm
@@ -10,7 +10,7 @@ use Log::Any '$log';
 use Time::HiRes 'time';
 
 
-our $VERSION = '0.41';
+our $VERSION = '0.42';
 
 
 my $SEPARATOR_ID_ACK = '#';


### PR DESCRIPTION
Previous versions of `AnyEvent::STOMP::Client` would include the `NULL` octet of a STOMP frame what was used as delimiter to indicate the end of the frame. According to the STOMP 1.2 specification [1] the `NULL` octet is not part of the body:

>  The body is then followed by the NULL octet.

This removes the trailing `NULL` octet from STMOP frames when said octet was used to delimit the very frame.

[1] https://stomp.github.io/stomp-specification-1.2.html